### PR TITLE
Connection details set invalid httpEndpoint value

### DIFF
--- a/config/ec/deployment.go
+++ b/config/ec/deployment.go
@@ -39,11 +39,11 @@ func Configure(p *config.Provider) {
 				if a, ok := attr[elasticsearch].([]interface{}); ok {
 					for i, nestedAttr := range a {
 						if nestedMap, ok := nestedAttr.(map[string]interface{}); ok {
-							if httpEndpoint, ok := nestedMap[httpEndpoint].(string); ok {
-								conn[fmt.Sprintf(endpointFmt, httpEndpoint, i)] = []byte(httpEndpoint)
+							if endpoint, ok := nestedMap[httpEndpoint].(string); ok {
+								conn[fmt.Sprintf(endpointFmt, httpEndpoint, i)] = []byte(endpoint)
 							}
-							if httpsEndpoint, ok := nestedMap[httpsEndpoint].(string); ok {
-								conn[fmt.Sprintf(endpointFmt, httpsEndpoint, i)] = []byte(httpsEndpoint)
+							if endpoint, ok := nestedMap[httpsEndpoint].(string); ok {
+								conn[fmt.Sprintf(endpointFmt, httpsEndpoint, i)] = []byte(endpoint)
 							}
 						}
 					}


### PR DESCRIPTION
### Description of your changes
Prior to this change, httpEndpoint was improperly being overwritten by the attr map lookup. This behavior resulted in the `conn` map having an invalid formatted key.

At the secret level, this resulted in the connection details secret not containing any of the set fields.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Deployed a new cluster locally and verified the connection details had the expected fields set:
```yaml
data:
  attribute.apm_secret_token: <REDACTED>
  attribute.elasticsearch_password: <REDACTED>
  elasticsearch_password: <REDACTED>
  elasticsearch_username: <REDACTED>
  http_endpoint_0: <REDACTED>
  https_endpoint_0: <REDACTED>
```

[contribution process]: https://git.io/fj2m9
